### PR TITLE
Removed Region default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Remove default value for AWS region.
+
 ## [0.1.1] - 2021-07-29
 
 ### Added

--- a/cmd/flag.go
+++ b/cmd/flag.go
@@ -32,7 +32,7 @@ func (f *flag) Init(cmd *cobra.Command) {
 	// Add command line flags for glog.
 	pflag.CommandLine.AddGoFlagSet(goflag.CommandLine)
 
-	cmd.Flags().StringVar(&f.Region, regionFlag, "eu-west-1", `The AWS region to use for the tests. Defaults to eu-west-1.`)
+	cmd.Flags().StringVar(&f.Region, regionFlag, "", `The AWS region to use for the tests.`)
 	cmd.Flags().IntVar(&f.FailThreshold, failThresholdFlag, 5, `How many failed probes in a row to consider kiam unhealthy. Defaults to 5.`)
 	cmd.Flags().IntVar(&f.Interval, intervalFlag, 60, `Interval in seconds to wait between tests. Defaults to 60.`)
 
@@ -43,6 +43,22 @@ func (f *flag) Init(cmd *cobra.Command) {
 
 func (f *flag) Validate(cmd *cobra.Command) error {
 	var err error
+
+	if f.Region == "" {
+		return fmt.Errorf("--%s can't be empty", regionFlag)
+	}
+
+	if f.KiamNamespace == "" {
+		return fmt.Errorf("--%s can't be empty", kiamNamespaceFlag)
+	}
+
+	if f.KiamLabelSelector == "" {
+		return fmt.Errorf("--%s can't be empty", kiamLabelSelectorFlag)
+	}
+
+	if f.NodeName == "" {
+		return fmt.Errorf("--%s can't be empty", nodeNameFlag)
+	}
 
 	if f.Interval <= 0 {
 		return fmt.Errorf("--%s should be greater than 0", intervalFlag)

--- a/helm/kiam-watchdog-app/templates/daemonset.yaml
+++ b/helm/kiam-watchdog-app/templates/daemonset.yaml
@@ -29,7 +29,9 @@ spec:
           image: "{{ .Values.image.registry }}/{{ .Values.image.name }}:{{ .Values.image.tag }}"
           imagePullPolicy: IfNotPresent
           args:
+          {{- if .Values.aws.region }}
           - "--region={{ .Values.aws.region }}"
+          {{- end }}
           - "--fail-threshold={{ .Values.kiamWatchdog.failThreshold }}"
           - "--interval={{ .Values.kiamWatchdog.interval }}"
           - "--kiam-namespace={{ .Values.kiamWatchdog.namespace }}"

--- a/helm/kiam-watchdog-app/values.yaml
+++ b/helm/kiam-watchdog-app/values.yaml
@@ -13,7 +13,7 @@ image:
   pullPolicy: IfNotPresent
 
 aws:
-  region: "eu-west-1"
+  region: ""
   iam:
     customRoleName: ""
 


### PR DESCRIPTION
the aws region flag is very important. If it is wrong, the kiam watchdog keeps restarting the kiam agents every 5 minutes.
For this reason I think removing the default and enforcing the user to set a proper value is important.

WDYT?