### PR TITLE
Added --probe-mode flag to allow using either 'route53' or 'sts' to probe AWS API.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added --probe-mode flag to allow using either 'route53' or 'sts' to probe AWS API.
+
 ## [0.4.0] - 2021-10-06
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
-[![CircleCI](https://circleci.com/gh/giantswarm/{APP-NAME}-app.svg?style=shield)](https://circleci.com/gh/giantswarm/{APP-NAME}-app)
+[![CircleCI](https://circleci.com/gh/giantswarm/kiam-watchdog/tree/master.svg?style=svg)](https://circleci.com/gh/giantswarm/kiam-watchdog/tree/master)
 
-# {APP-NAME} chart
+# Kiam watchdog
 
-Giant Swarm offers a {APP-NAME} App which can be installed in workload clusters.
-Here we define the {APP-NAME} chart with its templates and default configuration.
+This is an App that checks if kiam is working correctly and restarts it on a node if it's not.
 
 **What is this app?**
 **Why did we add it?**

--- a/cmd/errors.go
+++ b/cmd/errors.go
@@ -5,3 +5,7 @@ import "github.com/giantswarm/microerror"
 var invalidConfigError = &microerror.Error{
 	Kind: "invalidConfig",
 }
+
+var invalidProbeModeError = &microerror.Error{
+	Kind: "invalidProbeModeError",
+}

--- a/cmd/flag.go
+++ b/cmd/flag.go
@@ -13,6 +13,7 @@ const (
 	failThresholdFlag = "fail-threshold"
 	intervalFlag      = "interval"
 	probeModeFlag     = "probe-mode"
+	roleNameFlag      = "role-name"
 
 	kiamNamespaceFlag     = "kiam-namespace"
 	kiamLabelSelectorFlag = "kiam-label-selector"
@@ -26,12 +27,12 @@ type flag struct {
 	Region        string
 	FailThreshold int
 	Interval      int
+	ProbeMode     string
+	RoleName      string
 
 	KiamNamespace     string
 	KiamLabelSelector string
 	NodeName          string
-
-	ProbeMode string
 }
 
 func (f *flag) Init(cmd *cobra.Command) {
@@ -42,6 +43,7 @@ func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().IntVar(&f.FailThreshold, failThresholdFlag, 5, `How many failed probes in a row to consider kiam unhealthy. Defaults to 5.`)
 	cmd.Flags().IntVar(&f.Interval, intervalFlag, 60, `Interval in seconds to wait between tests. Defaults to 60.`)
 	cmd.Flags().StringVar(&f.ProbeMode, probeModeFlag, "sts", `What AWS API to use to check if kiam is working. Either "route53" or "sts". Defaults to "sts"`)
+	cmd.Flags().StringVar(&f.RoleName, roleNameFlag, "", `Name of the IAM role that kiam should make this pod assume. Used by the 'sts' probe mode.`)
 
 	cmd.Flags().StringVar(&f.KiamNamespace, kiamNamespaceFlag, "kube-system", `The namespace where kiam agent pods are running. Defaults to 'kube-system'`)
 	cmd.Flags().StringVar(&f.KiamLabelSelector, kiamLabelSelectorFlag, "component=kiam-agent", `The label selector to select kiam pods. Defaults to 'component=kiam-agent'`)
@@ -77,6 +79,10 @@ func (f *flag) Validate(cmd *cobra.Command) error {
 
 	if f.ProbeMode != probeModeSTS && f.ProbeMode != probeModeRoute53 {
 		return fmt.Errorf("--%s should be either %q or %q", probeModeFlag, probeModeSTS, probeModeRoute53)
+	}
+
+	if f.ProbeMode == probeModeSTS && f.RoleName == "" {
+		return fmt.Errorf("--%s can't be empty when --%s is %q", roleNameFlag, probeModeFlag, probeModeSTS)
 	}
 
 	// TODO validate AWS region.

--- a/cmd/flag.go
+++ b/cmd/flag.go
@@ -12,10 +12,14 @@ const (
 	regionFlag        = "region"
 	failThresholdFlag = "fail-threshold"
 	intervalFlag      = "interval"
+	probeModeFlag     = "probe-mode"
 
 	kiamNamespaceFlag     = "kiam-namespace"
 	kiamLabelSelectorFlag = "kiam-label-selector"
 	nodeNameFlag          = "node-name"
+
+	probeModeRoute53 = "route53"
+	probeModeSTS     = "sts"
 )
 
 type flag struct {
@@ -26,6 +30,8 @@ type flag struct {
 	KiamNamespace     string
 	KiamLabelSelector string
 	NodeName          string
+
+	ProbeMode string
 }
 
 func (f *flag) Init(cmd *cobra.Command) {
@@ -35,6 +41,7 @@ func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&f.Region, regionFlag, "", `The AWS region to use for the tests.`)
 	cmd.Flags().IntVar(&f.FailThreshold, failThresholdFlag, 5, `How many failed probes in a row to consider kiam unhealthy. Defaults to 5.`)
 	cmd.Flags().IntVar(&f.Interval, intervalFlag, 60, `Interval in seconds to wait between tests. Defaults to 60.`)
+	cmd.Flags().StringVar(&f.ProbeMode, probeModeFlag, "sts", `What AWS API to use to check if kiam is working. Either "route53" or "sts". Defaults to "sts"`)
 
 	cmd.Flags().StringVar(&f.KiamNamespace, kiamNamespaceFlag, "kube-system", `The namespace where kiam agent pods are running. Defaults to 'kube-system'`)
 	cmd.Flags().StringVar(&f.KiamLabelSelector, kiamLabelSelectorFlag, "component=kiam-agent", `The label selector to select kiam pods. Defaults to 'component=kiam-agent'`)
@@ -66,6 +73,10 @@ func (f *flag) Validate(cmd *cobra.Command) error {
 
 	if f.FailThreshold <= 0 {
 		return fmt.Errorf("--%s should be greater than 0", intervalFlag)
+	}
+
+	if f.ProbeMode != probeModeSTS && f.ProbeMode != probeModeRoute53 {
+		return fmt.Errorf("--%s should be either %q or %q", probeModeFlag, probeModeSTS, probeModeRoute53)
 	}
 
 	// TODO validate AWS region.

--- a/cmd/runner.go
+++ b/cmd/runner.go
@@ -61,8 +61,9 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 			})
 		case probeModeSTS:
 			prober, err = awsprober.NewSTS(awsprober.STSConfig{
-				Logger: r.logger,
-				Region: r.flag.Region,
+				Logger:       r.logger,
+				Region:       r.flag.Region,
+				ExpectedRole: r.flag.RoleName,
 			})
 		default:
 			return microerror.Maskf(invalidProbeModeError, "probe mode %q is not valid", r.flag.ProbeMode)

--- a/cmd/runner.go
+++ b/cmd/runner.go
@@ -49,13 +49,25 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 	r.logger.Debugf(ctx, "Interval: %d", r.flag.Interval)
 	r.logger.Debugf(ctx, "Fail Threshould: %d", r.flag.FailThreshold)
 	r.logger.Debugf(ctx, "AWS region: %q", r.flag.Region)
+	r.logger.Debugf(ctx, "Probe Mode: %q", r.flag.ProbeMode)
 
 	var prober awsprober.Interface
 	{
-		prober, err = awsprober.NewRoute53(awsprober.Route53Config{
-			Logger: r.logger,
-			Region: r.flag.Region,
-		})
+		switch r.flag.ProbeMode {
+		case probeModeRoute53:
+			prober, err = awsprober.NewRoute53(awsprober.Route53Config{
+				Logger: r.logger,
+				Region: r.flag.Region,
+			})
+		case probeModeSTS:
+			prober, err = awsprober.NewSTS(awsprober.STSConfig{
+				Logger: r.logger,
+				Region: r.flag.Region,
+			})
+		default:
+			return microerror.Maskf(invalidProbeModeError, "probe mode %q is not valid", r.flag.ProbeMode)
+		}
+
 		if err != nil {
 			return microerror.Mask(err)
 		}

--- a/helm/kiam-watchdog-app/templates/daemonset.yaml
+++ b/helm/kiam-watchdog-app/templates/daemonset.yaml
@@ -49,7 +49,7 @@ spec:
           - "--kiam-label-selector={{ .Values.kiamWatchdog.labelSelector }}"
           - "--node-name=$(K8S_NODE_NAME)"
           - "--probe-mode={{ .Values.kiamWatchdog.probeMode }}"
-          - "--role={{ template "aws.iam.role" . }}"
+          - "--role-name={{ template "aws.iam.role" . }}"
           env:
             - name: K8S_NODE_NAME
               valueFrom:

--- a/helm/kiam-watchdog-app/templates/daemonset.yaml
+++ b/helm/kiam-watchdog-app/templates/daemonset.yaml
@@ -48,6 +48,8 @@ spec:
           - "--kiam-namespace={{ .Values.kiamWatchdog.namespace }}"
           - "--kiam-label-selector={{ .Values.kiamWatchdog.labelSelector }}"
           - "--node-name=$(K8S_NODE_NAME)"
+          - "--probe-mode={{ .Values.kiamWatchdog.probeMode }}"
+          - "--role={{ template "aws.iam.role" . }}"
           env:
             - name: K8S_NODE_NAME
               valueFrom:

--- a/helm/kiam-watchdog-app/values.yaml
+++ b/helm/kiam-watchdog-app/values.yaml
@@ -24,6 +24,7 @@ kiamWatchdog:
   labelSelector: "component=kiam-agent"
   failThreshold: 5
   interval: 60
+  probeMode: "sts"
 
 # clusterID
 # The cluster's ID. It is dynamically set and will be overridden. Specific

--- a/pkg/awsprober/sts.go
+++ b/pkg/awsprober/sts.go
@@ -1,0 +1,49 @@
+package awsprober
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/sts"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+)
+
+type STSConfig struct {
+	Logger micrologger.Logger
+	Region string
+}
+
+type STS struct {
+	logger micrologger.Logger
+	region string
+}
+
+func NewSTS(config STSConfig) (*STS, error) {
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	return &STS{
+		logger: config.Logger,
+		region: config.Region,
+	}, nil
+}
+
+func (r *STS) Probe(ctx context.Context) bool {
+	sess, err := session.NewSessionWithOptions(session.Options{})
+	if err != nil {
+		r.logger.Errorf(ctx, err, "Error during AWS session setup")
+		return false
+	}
+
+	client := sts.New(sess)
+
+	_, err = client.GetCallerIdentity(nil)
+	if err != nil {
+		r.logger.Errorf(ctx, err, "Error calling sts.GetCallerIdentity")
+		return false
+	}
+
+	return true
+}

--- a/pkg/awsprober/sts.go
+++ b/pkg/awsprober/sts.go
@@ -2,6 +2,7 @@ package awsprober
 
 import (
 	"context"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/sts"
@@ -51,13 +52,13 @@ func (r *STS) Probe(ctx context.Context) bool {
 		return false
 	}
 
-	if identity.UserId == nil {
-		r.logger.Errorf(ctx, err, "sts.GetCallerIdentity returned nil userId")
+	if identity.Arn == nil {
+		r.logger.Errorf(ctx, err, "sts.GetCallerIdentity returned nil Arn")
 		return false
 	}
 
-	if *identity.UserId != r.expectedRole {
-		r.logger.Errorf(ctx, err, "Expected to have assumed role %q, but sts.GetCallerIdentity gave us %q", r.expectedRole, *identity.UserId)
+	if strings.HasSuffix(*identity.Arn, r.expectedRole) {
+		r.logger.Errorf(ctx, err, "Expected to have assumed role %q, but sts.GetCallerIdentity gave us Arn %q", r.expectedRole, *identity.Arn)
 		return false
 	}
 

--- a/pkg/awsprober/sts.go
+++ b/pkg/awsprober/sts.go
@@ -25,6 +25,9 @@ func NewSTS(config STSConfig) (*STS, error) {
 	if config.Logger == nil {
 		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
 	}
+	if config.ExpectedRole == "" {
+		return nil, microerror.Maskf(invalidConfigError, "%T.ExpectedRole must not be empty", config)
+	}
 
 	return &STS{
 		logger:       config.Logger,


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/20561

This PR adds a new flag to kiam-watchdog `--probe-mode` that allows to switch between `route53` and `sts` to probe for kiam being working.